### PR TITLE
    Allows skipping of the truncate step on strings

### DIFF
--- a/lib/firehose_integration/models/concerns/kinesis_event.rb
+++ b/lib/firehose_integration/models/concerns/kinesis_event.rb
@@ -17,6 +17,9 @@ module FirehoseIntegration
       def kinesis_stream_name
         raise(NoMethodError, "Model must define class method kinesis_stream_name")
       end
+      def skip_truncate
+        false
+      end
     end
 
     included do
@@ -26,7 +29,7 @@ module FirehoseIntegration
       end
 
       def prepare_for_redshift(field)
-        if field.present?
+        if field.present? && !self.class.skip_truncate
           if field.is_a? Array
             output = []
             field.each do |f|


### PR DESCRIPTION
    This will allow pushing of the full records to S3 for archiving and then
    let redshift handle the truncation of the longer strings during the COPY
    step